### PR TITLE
Deprecate Mosh recipes

### DIFF
--- a/Mosh/Mosh.download.recipe
+++ b/Mosh/Mosh.download.recipe
@@ -17,6 +17,15 @@
         <string>0.6.0</string>
         <key>Process</key>
         <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Mosh recipes in the Lotusshaney-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
             <dict>
                 <key>Processor</key>
                 <string>URLTextSearcher</string>


### PR DESCRIPTION
The Mosh download method is broken, and the recipes are redundant with the working recipes in the Lotusshaney-recipes repo. This PR deprecates the Mosh recipes.
