### PR TITLE
Deprecate PodmanDesktop recipes

### DIFF
--- a/PodmanDesktop/PodmanDesktop.download.recipe
+++ b/PodmanDesktop/PodmanDesktop.download.recipe
@@ -12,9 +12,18 @@
             <string>PodmanDesktop</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.5.0</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the PodmanDesktop recipes in the apettinen-recipes or gregneagle-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
This PR deprecates the PodmanDesktop recipes in this repo, which are not sufficiently distinct from the ones in gregneagle-recipes or apettinen-recipes to warrant the extra maintenance they will require.
