### PR TITLE
Use jleggat download recipe for MacVim parent

### DIFF
--- a/MacVim/MacVim.download.recipe
+++ b/MacVim/MacVim.download.recipe
@@ -17,6 +17,15 @@
         <array>
             <dict>
                 <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the MacVim recipes in the jleggat-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>
                 <key>Arguments</key>
                 <dict>

--- a/MacVim/MacVim.pkg.recipe
+++ b/MacVim/MacVim.pkg.recipe
@@ -12,7 +12,7 @@
         <string>MacVim</string>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.grumpydrew.download.MacVim</string>
+    <string>com.github.jleggat.MacVim.download</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The MacVim.download recipe in this repo is similar in function the earlier-created ones in jleggat-recipes. This PR adjusts your pkg recipe to use jleggat's download recipe as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

Verbose pkg recipe run:

```
% autopkg run -vvq 'drewdiver-recipes/MacVim/MacVim.pkg.recipe'
Processing drewdiver-recipes/MacVim/MacVim.pkg.recipe...
WARNING: drewdiver-recipes/MacVim/MacVim.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^.*.dmg$',
           'github_repo': 'macvim-dev/macvim',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^.*.dmg$' among asset(s): 179_to_181.delta, 180.2_to_181.delta, 180_to_181.delta, MacVim.dmg, MacVim_10.9.dmg
GitHubReleasesInfoProvider: Selected asset 'MacVim.dmg' from release 'MacVim r181'
{'Output': {'asset_created_at': '2025-02-21T02:47:39Z',
            'asset_url': 'https://api.github.com/repos/macvim-dev/macvim/releases/assets/231159423',
            'release_notes': 'Updated to Vim 9.1.1128\r\n'
                             '\r\n'
                             '[![MacVim release-181 '
                             'download](https://img.shields.io/github/downloads/macvim-dev/macvim/release-181/MacVim.dmg?label=macOS%2010.13%2B)](https://github.com/macvim-dev/macvim/releases/download/release-181/MacVim.dmg) '
                             '[![MacVim release-181 download '
                             '(10.9-10.12)](https://img.shields.io/github/downloads/macvim-dev/macvim/release-181/MacVim_10.9.dmg?label=macOS%2010.9-10.12)](https://github.com/macvim-dev/macvim/releases/download/release-181/MacVim_10.9.dmg)\r\n'
                             '\r\n'
                             'This update contains a completely new GUI tabs '
                             'implementation by @sfsam! It also contains lots '
                             'of small fixes for window resizing and full '
                             'screen mode that aims to make using MacVim feel '
                             'rock solid and stable.\r\n'
                             '\r\n'
                             'Defaults Change\r\n'
                             '====================\r\n'
                             '\r\n'
                             'New settings defaults related to window sizing '
                             '#1528:\r\n'
                             '\r\n'
                             '- "Smoothly resizes window" is now on by '
                             "default. MacVim's window will now resize "
                             'smoothly instead of snapped to the size of the '
                             'character grid.\r\n'
                             "- Vim's `guioptions` now has `k` set by default "
                             '([`:h '
                             "go-k`](https://macvim.org/docs/redirect.html?tag='go-k')). "
                             "This prevents MacVim's window size from changing "
                             'unnecessarily when showing/hiding tabs or '
                             'changing font size.\r\n'
                             '\r\n'
                             'These should align MacVim better with how other '
                             'apps work and integrate better with OS window '
                             "management, including macOS 15 Sequoia's window "
                             'tiling feature.\r\n'
                             '\r\n'
                             'Features\r\n'
                             '====================\r\n'
                             '\r\n'
                             'Tabs\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             'MacVim has a new tabs implementation! The old '
                             'version (PSMTabBarControl) is not maintained and '
                             'lacks features such as overflowing tabs and '
                             'customizable colors. The new tabs will overflow '
                             'horizontally and are scrollable. They also '
                             'animate when tabs are closed or moved, respect '
                             'system settings such as right-to-left locales '
                             'and high-contrast modes, and are designed to fit '
                             'within the currently selected Vim colors.\r\n'
                             '\r\n'
                             'There are a few ways to customize the colors of '
                             'the new tabs, under the "Appearance" settings '
                             'pane. MacVim defaults to an "Automatic colors" '
                             'mode which tries to pick sensible colors '
                             'automatically based on the current '
                             'foreground/background colors. However, you can '
                             'also configure it to simply use the tab colors '
                             'specified by the Vim color scheme (some color '
                             'schemes will work better than others depending '
                             'on their choice of colors). Another new option '
                             'is "Use tabs background color" which when '
                             'combined with "Transparent title bar" allows the '
                             'title bar and tabs to look like a single '
                             'cohesive whole.\r\n'
                             '\r\n'
                             '<img width="375" height="89.8693" alt="new tabs" '
                             'src="https://github.com/user-attachments/assets/f70a683e-1450-48d1-89b7-f6c12d73bf90" '
                             '/>\r\n'
                             '<img width="375" height="89.8693" alt="image" '
                             'src="https://github.com/user-attachments/assets/b1af9c2f-8176-43d8-add7-faf6272f9a74" '
                             '/>\r\n'
                             '<img width="375" height="89.8693" alt="new tabs" '
                             'src="https://github.com/user-attachments/assets/1190e1e4-2544-485c-adf5-86a57233f9a0" '
                             '/>\r\n'
                             '<img width="375" height="89.8693" alt="new tabs" '
                             'src="https://github.com/user-attachments/assets/93bc52e6-3559-48fa-8a28-5848fd19b1d7" '
                             '/>\r\n'
                             '\r\n'
                             'Relevant work:\r\n'
                             '\r\n'
                             '- #1120 (by @sfsam)\r\n'
                             '- Also: #1535 / #1536 / #1537 / #1538 / #1539 / '
                             '#1557 / #1558 / #1560\r\n'
                             '\r\n'
                             'New Vim features\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             '- new bundled color scheme:\r\n'
                             '    - unokai (vim/vim#16443)\r\n'
                             '- new bundled optional plugins (use `packadd` to '
                             'enable them):\r\n'
                             '    - helptoc: Use '
                             '[`:HelpToc`](https://macvim.org/docs/redirect.html?tag=:HelpToc) '
                             'to show an interactive table of contents for Vim '
                             'help, man pages, Markdown files, and terminal. '
                             'vim/vim#10446\r\n'
                             '- new options:\r\n'
                             '    - `set diffopt+=linematch:{n}`. Matches '
                             'lines better when in diff mode. '
                             '[v9.1.1009](https://github.com/vim/vim/commit/7c7a4e6d1ad50d5b25b42aa2d5a33a8d04a4cc8a)\r\n'
                             '    - `findfunc`. Customizes `:find` and other '
                             'commands. '
                             '[v9.1.0831](https://github.com/vim/vim/commit/a13f3a4f5de9c150f70298850e34747838904995)\r\n'
                             '    - `set completeopt+=preinsert`. Preview '
                             'inserted text in completion. '
                             '[v9.1.1056](https://github.com/vim/vim/commit/edd4ac3e895ce16034c7e098f1d68e0155d97886)\r\n'
                             '    - `messagesopt`. Allows customizing '
                             'hit-enter behavior. '
                             '[v9.1.0908](https://github.com/vim/vim/commit/51d4d84d6a7159c6ce9e04b36f8edc105ca3794b)\r\n'
                             '- new functions:\r\n'
                             '    - `getcellpixels()`. Query the pixel size of '
                             'a character cell in the grid. '
                             '[v9.1.0854](https://github.com/vim/vim/commit/1083cae7091f006249c1349d0575412d2ff6a7dc) '
                             '/ #1554 / #1555\r\n'
                             '- Vim tutor has a new interactive plugin ([`:h '
                             ':Tutor`](https://macvim.org/docs/redirect.html?tag=:Tutor)) '
                             '([v9.1.0836](https://github.com/vim/vim/commit/a54816b884157f6b7973a188f85c708d15cbf72f)). '
                             'There is also now a chapter 2 (vim/vim#5729).\r\n'
                             '\r\n'
                             'Misc New Settings\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             '- "Open untitled window" (General) has a new '
                             'option to only open on MacVim re-activation. '
                             '#1509\r\n'
                             '- "Show document icon at title bar" '
                             '(Appearance). Previously MacVim implicitly hid '
                             'the document icon when using transparent title '
                             'bar. This is now customizable. #1510\r\n'
                             '\r\n'
                             'General\r\n'
                             '====================\r\n'
                             '\r\n'
                             '- The MacVim dmg installer has a new design. '
                             'Courtesy of @jasonlong. #1540 #1545\r\n'
                             '\r\n'
                             '- Legacy builds (macOS 10.9 - 10.12) are no '
                             'longer built by GitHub hosted runners, due to '
                             "GitHub's deprecation of old runners. They are "
                             'now built by a custom self-hosted VM instead. In '
                             'the future we hope to set up reproducible builds '
                             "(#1506) so it will not matter who's building the "
                             'app as it would be verifiable. #1559\r\n'
                             '\r\n'
                             '- "Nightly" build: We now build a dmg installer '
                             'for every commit. This allows for trying out the '
                             'latest developmental version of MacVim, but note '
                             'that the app will not be signed / notarized, and '
                             'it will not be as polished as official '
                             'release/pre-release builds. See '
                             '[wiki](https://github.com/macvim-dev/macvim/wiki/Installing) '
                             'for instructions. #1532\r\n'
                             '\r\n'
                             'Fixes\r\n'
                             '====================\r\n'
                             '\r\n'
                             'Apple "Intelligence" Writing Tools\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             'macOS 15 Sequoia\'s Apple "Intelligence" Writing '
                             'Tools should work correctly with MacVim now. To '
                             'use it, select some text, right click to show '
                             'menu, and then select the "Writing Tools" '
                             'sub-menu. As part of this fix, the integration '
                             'with the "Services" menu now works more reliably '
                             'as well. You can select texts in blockwise '
                             'visual mode and select a service and MacVim will '
                             'try to place the new texts back to the blockwise '
                             'selection if possible. #1552\r\n'
                             '\r\n'
                             'Window resizing and full screen\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             '- Flicker begone: Changing font size, '
                             'showing/hiding tabs or scroll bars, or entering '
                             'non-native full screen should no longer cause '
                             'MacVim to flicker. Previously there could be a '
                             'momentary but distracting/annoying stale image '
                             'that flashes briefly. #1547 #1549\r\n'
                             '- Fixed issue where resizing MacVim window would '
                             'occasionally cause Vim to be stuck in a stale '
                             'wrong size. #1518\r\n'
                             '- Non-native full screen now supports '
                             '`blurradius` option. #1546\r\n'
                             '- Fixed window size not always restoring '
                             'correctly when exiting full screen. Non-native '
                             'full screen also works more reliably in '
                             'multi-monitor setup. #1525\r\n'
                             '- Fixed non-native full screen mode when using '
                             'an external monitor with a MacBook with a notch, '
                             'and having the "Show menu bar in non-native '
                             'mode" option set. Previously MacVim would '
                             'sometimes miscalculate the menu bar height in '
                             'the second screen. #1548\r\n'
                             '- Fixed misc issues with non-native full '
                             "screen's interaction with `fuoptions` and also "
                             'the `transparency` setting, and rare crash. '
                             '#1521\r\n'
                             '\r\n'
                             'Other Fixes\r\n'
                             '--------------------\r\n'
                             '\r\n'
                             '- Fixed issue where changing font size (using '
                             'Cmd =/-) with guifont set to "-monospace-" would '
                             'result in guifont being changed to a confusing '
                             'name like '
                             '".AppleSystemUIFontMonospaced-Regular". #1544\r\n'
                             '- "MacVim Website" menu item now goes to the '
                             'updated URL. #1524\r\n'
                             "- What's New page now allows changing font size "
                             '(using Cmd =/-), and showing table of contents. '
                             '#1561 #1562\r\n'
                             '- Dark mode documentation is now a bit clearer '
                             'on `v:os_appearance`. #1511\r\n'
                             '- Using dictionary look up on selected texts (by '
                             'right clicking and then selecting "Look Up" in '
                             'the pop-up menu) is now more resilient as it '
                             "uses Vim's native `getregion()` to determine the "
                             'selected texts. #1508\r\n'
                             '\r\n'
                             'Scripting\r\n'
                             '====================\r\n'
                             '\r\n'
                             '- Scripting languages versions:\r\n'
                             '    - Ruby is now built against 3.4, up from '
                             '3.3.\r\n'
                             '    - Perl is now built against 5.34, up from '
                             '5.30.\r\n'
                             '\r\n'
                             '<details><summary>Compatibility</summary>\r\n'
                             '\r\n'
                             'Compatibility\r\n'
                             '====================\r\n'
                             '\r\n'
                             'Requires macOS 10.9 or above. (10.9 - 10.12 '
                             'requires downloading a separate legacy build)\r\n'
                             '\r\n'
                             'Script interfaces have compatibility with these '
                             'versions:\r\n'
                             '\r\n'
                             '- Lua 5.4\r\n'
                             '- Perl 5.34\r\n'
                             '- Python2 2.7\r\n'
                             '- Python3 3.9 or above\r\n'
                             '- Ruby 3.4\r\n'
                             '\r\n'
                             '</details>',
            'url': 'https://github.com/macvim-dev/macvim/releases/download/release-181/MacVim.dmg',
            'version': 'release-181'}}
URLDownloader
{'Input': {'filename': 'MacVim.dmg',
           'url': 'https://github.com/macvim-dev/macvim/releases/download/release-181/MacVim.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 21 Feb 2025 02:47:42 GMT
URLDownloader: Storing new ETag header: "0x8DD52221CB7A440"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD52221CB7A440"',
            'last_modified': 'Fri, 21 Feb 2025 02:47:42 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg/MacVim.app',
           'requirement': 'identifier "org.vim.MacVim" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'WG3S88DD2E',
           'strict_verification': True}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.3IjrhR/MacVim.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3IjrhR/MacVim.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3IjrhR/MacVim.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg
AppDmgVersioner: BundleID: org.vim.MacVim
AppDmgVersioner: Version: 9.1.1128
{'Output': {'app_name': 'MacVim.app',
            'bundleid': 'org.vim.MacVim',
            'version': '9.1.1128'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim/Applications/MacVim.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg/MacVim.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg, dmg: .dmg/, dmg_source_path: MacVim.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg
Copier: Copied /private/tmp/dmg.mATcV2/MacVim.app to ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim/Applications/MacVim.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'org.vim.MacVim',
                           'options': 'purge_ds_store',
                           'pkgname': 'MacVim-9.1.1128',
                           'version': '9.1.1128'}}}
PkgCreator: No value supplied for force_pkg_build, setting default value of: False
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'org.vim.MacVim',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim-9.1.1128.pkg',
                                                    'version': '9.1.1128'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim-9.1.1128.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/receipts/MacVim.pkg-receipt-20251026-201853.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/downloads/MacVim.dmg  

The following packages were built:
    Identifier      Version   Pkg Path                                                                                  
    ----------      -------   --------                                                                                  
    org.vim.MacVim  9.1.1128  ~/Library/AutoPkg/Cache/com.github.grumpydrew.pkg.MacVim/MacVim-9.1.1128.pkg 
```